### PR TITLE
setImmediate check tweak

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 // monkey-patch choo's nanobus emitter
 // so that every event is async with setImmediate() / setTimeout(fn, 0)
-var asyncify = setImmediate || function (fn) { setTimeout(fn, 0) }
+var asyncify = typeof setImmediate === "function"
+  ? setImmediate
+  : function (fn) { setTimeout(fn, 0) }
 
 module.exports = function (state, emitter) {
   var _emit = emitter.emit


### PR DESCRIPTION
hey this is great, thanks! came in handy in a project i'm currently working on. I was actually getting a `Uncaught ReferenceError: setImmediate is not defined` so I slightly adjusted how  `asyncify` is defined:

```js
var asyncify = typeof setImmediate === "function"
  ? setImmediate
  : function (fn) { setTimeout(fn, 0) }
```